### PR TITLE
Update Dockerfile to reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /usr/src/app
 
 COPY ./ ./
 
-RUN yarn install
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 RUN yarn build
 
+EXPOSE 3000
 CMD ["yarn", "start"]


### PR DESCRIPTION
ビルド後のコンテナのサイズを小さくするために Dockerfile を簡単に出来る範囲でアップデートしました。
手元の環境では 2.68GB -> 761.02MB までビルド後のコンテナサイズを小さくできましたので、もしよければマージしてください。